### PR TITLE
Improve templates with Tailwind and load i18n

### DIFF
--- a/store/views.py
+++ b/store/views.py
@@ -1,9 +1,12 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
+from .models import Product
 
 
-def product_list(request):
-    return render(request, "store/product_list.html")
+def product_list(request):  # Display all products
+    products = Product.objects.all()
+    return render(request, "store/product_list.html", {"products": products})
 
 
-def product_detail(request, pk):
-    return render(request, "store/product_detail.html")
+def product_detail(request, pk):  # Show single product
+    product = get_object_or_404(Product, pk=pk)
+    return render(request, "store/product_detail.html", {"product": product})

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <!DOCTYPE html>
 <html lang="{% get_current_language %}">
 <head>
@@ -5,18 +6,32 @@
     <title>{% block title %}Ecommerce{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body>
-    <header class="p-4 bg-gray-100 flex justify-end">
-        <form action="/i18n/setlang/" method="post">
-            {% csrf_token %}
-            <select name="language" onchange="this.form.submit()" class="mr-2 border rounded p-1">
-                <option value="en" {% if LANGUAGE_CODE == 'en' %}selected{% endif %}>English</option>
-                <option value="es" {% if LANGUAGE_CODE == 'es' %}selected{% endif %}>Español</option>
-            </select>
-        </form>
+<body class="flex flex-col min-h-screen">
+    <header class="bg-gray-100">
+        <div class="container mx-auto flex justify-between items-center p-4">
+            <a href="{% url 'product_list' %}" class="text-xl font-bold">E-Shop</a>
+            <div class="flex items-center space-x-4">
+                <form action="/i18n/setlang/" method="post">
+                    {% csrf_token %}
+                    <select name="language" onchange="this.form.submit()" class="border rounded p-1">
+                        <option value="en" {% if LANGUAGE_CODE == 'en' %}selected{% endif %}>English</option>
+                        <option value="es" {% if LANGUAGE_CODE == 'es' %}selected{% endif %}>Español</option>
+                    </select>
+                </form>
+                {% if user.is_authenticated %}
+                    <a href="{% url 'logout' %}" class="text-blue-500 hover:underline">{% trans "Logout" %}</a>
+                {% else %}
+                    <a href="{% url 'login' %}" class="text-blue-500 hover:underline">{% trans "Login" %}</a>
+                    <a href="{% url 'register' %}" class="text-blue-500 hover:underline">{% trans "Register" %}</a>
+                {% endif %}
+            </div>
+        </div>
     </header>
-    <main class="container mx-auto p-4">
+    <main class="container mx-auto p-4 flex-grow">
         {% block content %}{% endblock %}
     </main>
+    <footer class="bg-gray-100 text-center p-4">
+        <p>&copy; 2024 E-Shop</p>
+    </footer>
 </body>
 </html>

--- a/templates/store/product_detail.html
+++ b/templates/store/product_detail.html
@@ -1,6 +1,14 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% trans "Product Detail" %}{% endblock %}
+{% block title %}{{ product.name }}{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">{% trans "Product Detail" %}</h1>
+<div class="max-w-2xl mx-auto">
+    <a href="{% url 'product_list' %}" class="text-blue-500 hover:underline mb-4 inline-block">{% trans "Back" %}</a>
+    {% if product.image %}
+    <img src="{{ product.image.url }}" alt="{{ product.name }}" class="w-full mb-4 rounded">
+    {% endif %}
+    <h1 class="text-3xl font-bold mb-2">{{ product.name }}</h1>
+    <p class="text-xl font-semibold mb-4">${{ product.price }}</p>
+    <p class="mb-6">{{ product.description }}</p>
+</div>
 {% endblock %}

--- a/templates/store/product_list.html
+++ b/templates/store/product_list.html
@@ -2,5 +2,19 @@
 {% load i18n %}
 {% block title %}{% trans "Product List" %}{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">{% trans "Products" %}</h1>
+<h1 class="text-2xl font-bold mb-6">{% trans "Products" %}</h1>
+<div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+    {% for product in products %}
+    <div class="border rounded p-4 flex flex-col hover:shadow">
+        {% if product.image %}
+        <img src="{{ product.image.url }}" alt="{{ product.name }}" class="mb-4 h-40 w-full object-cover rounded">
+        {% endif %}
+        <h2 class="font-semibold mb-2">{{ product.name }}</h2>
+        <p class="text-lg font-bold mb-4">${{ product.price }}</p>
+        <a href="{% url 'product_detail' product.pk %}" class="mt-auto bg-blue-500 text-white rounded p-2 text-center hover:bg-blue-600">{% trans "View" %}</a>
+    </div>
+    {% empty %}
+    <p>{% trans "No products available." %}</p>
+    {% endfor %}
+</div>
 {% endblock %}

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -2,5 +2,23 @@
 {% load i18n %}
 {% block title %}{% trans "Login" %}{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">{% trans "Login" %}</h1>
+<div class="max-w-sm mx-auto">
+    <h1 class="text-2xl font-bold mb-6 text-center">{% trans "Login" %}</h1>
+    <form method="post" class="bg-white shadow rounded p-6">
+        {% csrf_token %}
+        {% if form.non_field_errors %}
+        <p class="text-red-500 text-sm mb-4">{{ form.non_field_errors }}</p>
+        {% endif %}
+        {% for field in form %}
+        <div class="mb-4">
+            {{ field.label_tag }}
+            {{ field.as_widget(attrs={'class':'w-full border rounded p-2'}) }}
+            {% for error in field.errors %}
+            <p class="text-red-500 text-sm">{{ error }}</p>
+            {% endfor %}
+        </div>
+        {% endfor %}
+        <button type="submit" class="w-full bg-blue-500 text-white rounded p-2 hover:bg-blue-600">{% trans "Login" %}</button>
+    </form>
+</div>
 {% endblock %}

--- a/templates/users/register.html
+++ b/templates/users/register.html
@@ -2,5 +2,23 @@
 {% load i18n %}
 {% block title %}{% trans "Register" %}{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">{% trans "Register" %}</h1>
+<div class="max-w-sm mx-auto">
+    <h1 class="text-2xl font-bold mb-6 text-center">{% trans "Register" %}</h1>
+    <form method="post" class="bg-white shadow rounded p-6">
+        {% csrf_token %}
+        {% if form.non_field_errors %}
+        <p class="text-red-500 text-sm mb-4">{{ form.non_field_errors }}</p>
+        {% endif %}
+        {% for field in form %}
+        <div class="mb-4">
+            {{ field.label_tag }}
+            {{ field.as_widget(attrs={'class':'w-full border rounded p-2'}) }}
+            {% for error in field.errors %}
+            <p class="text-red-500 text-sm">{{ error }}</p>
+            {% endfor %}
+        </div>
+        {% endfor %}
+        <button type="submit" class="w-full bg-blue-500 text-white rounded p-2 hover:bg-blue-600">{% trans "Register" %}</button>
+    </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load i18n tags in `base.html`
- build responsive header with language switcher and auth links
- use Tailwind for product list grid and product detail view
- style login and register forms with Tailwind
- query products in store views

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687535d42bd8832cb4429fba7d8b696c